### PR TITLE
chore(docs): add purgeCSS config object example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ If you want to set a different path for the configuration file or css file, you 
 }
 ```
 
+If you want to set any (additional) purgeCSS configuration options, you can add a purgeCSS configuration object:
+
+```js
+// nuxt.config.js
+{
+  purgeCSS: {
+    whitelist: ['css-selector-to-whitelist'],
+  },
+}
+```
+
 ## Development
 
 1. Clone this repository

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ If you want to set any (additional) purgeCSS configuration options, you can add 
 }
 ```
 
+See full options here: https://github.com/Developmint/nuxt-purgecss#options
+
 ## Development
 
 1. Clone this repository


### PR DESCRIPTION
Feels like it should be part of the readme. Took me a while to find where to add this.